### PR TITLE
force django 1.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psycopg2==2.6.1
-django>=1.9.0
+django==1.9.0
 djangorestframework >=3.0.0
 celery>=3.1.18
 django-celery>=3.1.17


### PR DESCRIPTION
signalserver breaks with version 1.11, see
https://github.com/bavc/signalserver/issues/226.

fixes https://github.com/bavc/signalserver/issues/226