### PR TITLE
Ensure bower components are in frontend directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,4 @@ RUN mkdir -p /var/signalserver/files/policies
 RUN useradd -ms /bin/bash signalserversadmin
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash && apt-get install -y nodejs
 RUN npm install -g bower
-COPY ./frontend/bower.json bower.json
-RUN bower install --allow-root
+RUN cd frontend && bower install --allow-root


### PR DESCRIPTION
Bower components were not accessible, so we had many `404` errors and a non fully functional GUI.
This fixes #299.